### PR TITLE
Command prefix name change from FT to search (#192)

### DIFF
--- a/src/dep/rmr/command.c
+++ b/src/dep/rmr/command.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+#include "../../version.h"
 
 /*
  * Forward declaration
@@ -69,7 +70,7 @@ struct mrCommandConf __commandConfig[] = {
     {"FT.CREATE", MRCommand_Read | MRCommand_Coordination, -1, 1, NULL},
     {"FT.RULEADD", MRCommand_Read | MRCommand_Coordination, -1, 1, NULL},
     {"FT.RULESET", MRCommand_Read | MRCommand_Coordination, -1, 1, NULL},
-    {"FT.CLUSTERINFO", MRCommand_Read | MRCommand_Coordination, -1, -1, NULL},
+    {RSCOORDINATOR_MODULE_NAME".CLUSTERINFO", MRCommand_Read | MRCommand_Coordination, -1, -1, NULL},
     {"FT.INFO", MRCommand_Read | MRCommand_Coordination, -1, 1, NULL},
     {"FT.ADDHASH", MRCommand_Read | MRCommand_Coordination, -1, 2, NULL},
     {"FT.DEL", MRCommand_Read | MRCommand_Coordination, -1, 2, NULL},

--- a/src/dep/rmr/redis_cluster.c
+++ b/src/dep/rmr/redis_cluster.c
@@ -3,6 +3,7 @@
 #include <uv.h>
 #include <redismodule.h>
 #include "dep/RediSearch/src/rmutil/periodic.h"
+#include "../../version.h"
 
 #define REDIS_CLUSTER_REFRESH_TIMEOUT 1000
 
@@ -115,7 +116,7 @@ static int updateTopoCB(RedisModuleCtx *ctx, void *p) {
   RedisModule_ThreadSafeContextLock(ctx);
   RedisModule_AutoMemory(ctx);
 
-  RedisModuleCallReply *r = RedisModule_Call(ctx, "FT.CLUSTERREFRESH", "");
+  RedisModuleCallReply *r = RedisModule_Call(ctx, RSCOORDINATOR_MODULE_NAME".CLUSTERREFRESH", "");
   if (RedisModule_CallReplyType(r) == REDIS_REPLY_ERROR) {
     fprintf(stderr, "Error running CLUSTERREFRESH: %s\n", RedisModule_CallReplyStringPtr(r, NULL));
   }


### PR DESCRIPTION
* Update redis_cluster.c

Change "FT.CLUSTERREFRESH" to RSCOORDINATOR_MODULE_NAME".CLUSTERREFRESH"

* Update command.c

Change "FT.CLUSTERINFO" to RSCOORDINATOR_MODULE_NAME".CLUSTERINFO"