### PR TITLE
[2.2] Update coordination strategy of FlatSearchCommandHandler

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1225,7 +1225,7 @@ int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, RedisModuleString **a
   struct MRCtx *mrctx = MR_CreateCtx(ctx, req);
   // we prefer the next level to be local - we will only approach nodes on our own shard
   // we also ask only masters to serve the request, to avoid duplications by random
-  MR_SetCoordinationStrategy(mrctx, MRCluster_FlatCoordination);
+  MR_SetCoordinationStrategy(mrctx, MRCluster_FlatCoordination | MRCluster_MastersOnly);
 
   MRCtx_SetReduceFunction(mrctx, searchResultReducer);
   MRCtx_SetRedisCtx(mrctx, bc);


### PR DESCRIPTION
Add MRCluster_MastersOnly to the coordination strategy of the FlatSearchCommandHandler
This fixes #326 